### PR TITLE
Lazy loading

### DIFF
--- a/include/vega/dicom/data_element.h
+++ b/include/vega/dicom/data_element.h
@@ -66,7 +66,7 @@ namespace vega {
      * Note that it is usually easier to use the wrapper class \link Element Element<T>\endlink
      * instead of DataElement when dealing with raw data.
      */
-    class DataElement {
+    class DataElement : public std::enable_shared_from_this<DataElement> {
       private:
         DataElementHeader m_header;
         std::shared_ptr<const dictionary::Page> m_page;
@@ -116,6 +116,8 @@ namespace vega {
          * \param parent is the parent DataSet of the DataElement (`nullptr` when at the root of the DICOM file)
          */
         DataElement(const Tag& tag, const VR& vr, std::shared_ptr<DataSet> parent = nullptr);
+
+        std::shared_ptr<DataElement> get_shared_ptr();
 
         static std::shared_ptr<DataElement> from_json(std::stringstream& json_string, const Tag& tag, std::shared_ptr<DataSet> parent = nullptr);
 

--- a/include/vega/dicom/data_element.h
+++ b/include/vega/dicom/data_element.h
@@ -122,7 +122,7 @@ namespace vega {
          */
         DataElement(const Tag& tag, const VR& vr, std::shared_ptr<DataSet> parent = nullptr);
 
-        void set_value_field(std::shared_ptr<Reader> reader, std::streampos start);
+        void set_value_field(const std::shared_ptr<Reader>& reader, const std::streampos& start);
 
         static std::shared_ptr<DataElement> from_json(std::stringstream& json_string, const Tag& tag, std::shared_ptr<DataSet> parent = nullptr);
 
@@ -153,8 +153,9 @@ namespace vega {
         std::vector<std::shared_ptr<DataSet>>& data_sets();
 
         /// \cond INTERNAL
-        std::shared_ptr<manipulators::ValueManipulator> manipulator() { return m_manipulator; }
+        std::shared_ptr<manipulators::ValueManipulator> manipulator() { lazy_load(); return m_manipulator; }
         std::shared_ptr<const manipulators::ValueManipulator> manipulator() const {
+          lazy_load();
           return std::static_pointer_cast<const manipulators::ValueManipulator>(m_manipulator);
         }
         /// \endcond
@@ -166,6 +167,7 @@ namespace vega {
         template <typename T>
         void set_manipulator(std::shared_ptr<T> manipulator) {
           this->validate_manipulator(*manipulator);
+          lazy_load();
           m_manipulator = std::dynamic_pointer_cast<manipulators::ValueManipulator>(manipulator);
         }
 
@@ -186,6 +188,7 @@ namespace vega {
         template <typename T>
         std::shared_ptr<T> get_manipulator() {
           this->vr().validate_value_manipulator<T>();
+          lazy_load();
 
           // Brand new
           if (!m_manipulator) {
@@ -212,16 +215,20 @@ namespace vega {
         /// \endcond
 
         std::vector<std::shared_ptr<DataSet>>::iterator begin() {
+          lazy_load();
           return m_data_sets.begin();
         }
         std::vector<std::shared_ptr<DataSet>>::const_iterator begin() const {
+          lazy_load();
           return m_data_sets.begin();
         }
 
         std::vector<std::shared_ptr<DataSet>>::iterator end() {
+          lazy_load();
           return m_data_sets.end();
         }
         std::vector<std::shared_ptr<DataSet>>::const_iterator end() const {
+          lazy_load();
           return m_data_sets.end();
         }
 

--- a/include/vega/dicom/data_element.h
+++ b/include/vega/dicom/data_element.h
@@ -4,6 +4,7 @@
 #include <memory>
 #include <vector>
 #include <string>
+#include <mutex>
 
 #include "vega/vega.h"
 #include "vega/dicom/data_element_header.h"
@@ -80,6 +81,9 @@ namespace vega {
         std::streampos m_start;
 
         mutable std::shared_ptr<manipulators::ValueManipulator> m_manipulator;
+
+        // For making lazy loading thread-safe
+        mutable std::mutex m_mutex;
 
       public:
         /// Creates a blank DataElement with the given \p parent.

--- a/include/vega/dicom/data_element.h
+++ b/include/vega/dicom/data_element.h
@@ -166,8 +166,8 @@ namespace vega {
          */
         template <typename T>
         void set_manipulator(std::shared_ptr<T> manipulator) {
-          this->validate_manipulator(*manipulator);
           lazy_load();
+          this->validate_manipulator(*manipulator);
           m_manipulator = std::dynamic_pointer_cast<manipulators::ValueManipulator>(manipulator);
         }
 
@@ -247,8 +247,8 @@ namespace vega {
         }
 
         void lazy_load() const;
-        void read_finite_sequence() const;
-        void read_value_field() const;
+        void read_finite_sequence(const std::shared_ptr<Reader>& reader) const;
+        void read_value_field(const std::shared_ptr<Reader>& reader) const;
     };
   }
 }

--- a/include/vega/dicom/data_set.h
+++ b/include/vega/dicom/data_set.h
@@ -26,7 +26,7 @@ namespace vega {
      * Simply put a DataSet is a map from \link Tag Tags\endlink to \link DataElement DataElements\endlink,
      * and so there can be at most one DataElement per Tag.
      */
-    class DataSet {
+    class DataSet : public std::enable_shared_from_this<DataSet> {
       public:
         typedef uint32_t length_type;
 
@@ -79,6 +79,8 @@ namespace vega {
          * \param parent is the parent DataElement of this DataSet (`nullptr` when this DataSet is at the root of the DICOM file)
          */
         DataSet(std::shared_ptr<DataElement> parent = nullptr);
+
+        std::shared_ptr<DataSet> get_shared_ptr();
 
         static std::shared_ptr<DataSet> from_json(const std::string& json_string);
         static std::shared_ptr<DataSet> from_json(std::stringstream& json_string, std::shared_ptr<DataElement> parent = nullptr);

--- a/include/vega/dicom/data_set.h
+++ b/include/vega/dicom/data_set.h
@@ -80,8 +80,6 @@ namespace vega {
          */
         DataSet(std::shared_ptr<DataElement> parent = nullptr);
 
-        std::shared_ptr<DataSet> get_shared_ptr();
-
         static std::shared_ptr<DataSet> from_json(const std::string& json_string);
         static std::shared_ptr<DataSet> from_json(std::stringstream& json_string, std::shared_ptr<DataElement> parent = nullptr);
 

--- a/include/vega/dicom/file.h
+++ b/include/vega/dicom/file.h
@@ -36,7 +36,7 @@ namespace vega {
          * \param allow_any_explicit_vr will skip checking the dictionary to see if any element's
          *        VR is valid if the DICOM file has explicit VR.
          */
-        File(const std::string& file_name, bool allow_any_explicit_vr = false);
+        File(const std::string& file_name, bool allow_any_explicit_vr = false, bool lazy_load = false);
 
         /**
          * \brief Reads in existing file from a user supplied input stream \p input.
@@ -46,7 +46,7 @@ namespace vega {
          * \param allow_any_explicit_vr will skip checking the dictionary to see if any element's
          *        VR is valid if the DICOM file has explicit VR.
          */
-        File(std::shared_ptr<std::istream> input, bool allow_any_explicit_vr = false);
+        File(std::shared_ptr<std::istream> input, bool allow_any_explicit_vr = false, bool lazy_load = false);
 
         /**
          * \brief Builds a blank DICOM file.

--- a/include/vega/dicom/file.h
+++ b/include/vega/dicom/file.h
@@ -36,7 +36,7 @@ namespace vega {
          * \param allow_any_explicit_vr will skip checking the dictionary to see if any element's
          *        VR is valid if the DICOM file has explicit VR.
          */
-        File(const std::string& file_name, bool allow_any_explicit_vr = false, bool lazy_load = false);
+        File(const std::string& file_name, bool allow_any_explicit_vr = false, bool lazy_load = true);
 
         /**
          * \brief Reads in existing file from a user supplied input stream \p input.
@@ -46,7 +46,7 @@ namespace vega {
          * \param allow_any_explicit_vr will skip checking the dictionary to see if any element's
          *        VR is valid if the DICOM file has explicit VR.
          */
-        File(std::shared_ptr<std::istream> input, bool allow_any_explicit_vr = false, bool lazy_load = false);
+        File(std::shared_ptr<std::istream> input, bool allow_any_explicit_vr = false, bool lazy_load = true);
 
         /**
          * \brief Builds a blank DICOM file.

--- a/include/vega/dicom/reader.h
+++ b/include/vega/dicom/reader.h
@@ -57,6 +57,7 @@ namespace vega {
         bool eof();
         void rewind();
         std::streampos tell();
+        std::streampos eof_pos() const;
         void seek_pos(std::streampos pos);
         void seek_delta(std::streampos delta);
     };

--- a/include/vega/dicom/reader.h
+++ b/include/vega/dicom/reader.h
@@ -37,8 +37,6 @@ namespace vega {
       public:
         Reader(std::shared_ptr<std::istream> is, bool allow_any_explicit_vr = false);
 
-        std::shared_ptr<Reader> get_shared_ptr();
-
         RawReader& raw_reader();
 
         const Endian& dicom_endian() const;
@@ -64,8 +62,8 @@ namespace vega {
         void seek_delta(std::streampos delta);
 
       private:
-        void read_data_element_finite_sequence(std::shared_ptr<DataElement> element);
         void read_data_element_undefined_sequence(std::shared_ptr<DataElement> element);
+        void read_data_element_finite_sequence(std::shared_ptr<DataElement> element);
         void read_data_element_value_field(std::shared_ptr<DataElement> element);
     };
   }

--- a/include/vega/dicom/reader.h
+++ b/include/vega/dicom/reader.h
@@ -33,9 +33,10 @@ namespace vega {
         Formatter m_formatter;
         RawReader m_raw_reader;
         bool m_allow_any_explicit_vr;
+        bool m_lazy_load;
 
       public:
-        Reader(std::shared_ptr<std::istream> is, bool allow_any_explicit_vr = false);
+        Reader(std::shared_ptr<std::istream> is, bool allow_any_explicit_vr = false, bool lazy_load = false);
 
         RawReader& raw_reader();
 
@@ -63,6 +64,7 @@ namespace vega {
 
       private:
         void read_data_element_undefined_sequence(std::shared_ptr<DataElement> element);
+        void read_data_element_finite_sequence(std::shared_ptr<DataElement> element);
         void read_data_element_value_field(std::shared_ptr<DataElement> element);
     };
   }

--- a/include/vega/dicom/reader.h
+++ b/include/vega/dicom/reader.h
@@ -24,7 +24,7 @@ namespace vega {
   }
 
   namespace dicom {
-    class Reader {
+    class Reader : public std::enable_shared_from_this<Reader> {
       public:
         class FileDoesNotExistError : public vega::Exception { using vega::Exception::Exception; };
         class ReadingError : public vega::Exception { using vega::Exception::Exception; };
@@ -36,6 +36,8 @@ namespace vega {
 
       public:
         Reader(std::shared_ptr<std::istream> is, bool allow_any_explicit_vr = false);
+
+        std::shared_ptr<Reader> get_shared_ptr();
 
         RawReader& raw_reader();
 

--- a/include/vega/dicom/reader.h
+++ b/include/vega/dicom/reader.h
@@ -63,8 +63,6 @@ namespace vega {
 
       private:
         void read_data_element_undefined_sequence(std::shared_ptr<DataElement> element);
-        void read_data_element_finite_sequence(std::shared_ptr<DataElement> element);
-        void read_data_element_value_field(std::shared_ptr<DataElement> element);
     };
   }
 }

--- a/include/vega/dicom/reader.h
+++ b/include/vega/dicom/reader.h
@@ -36,7 +36,7 @@ namespace vega {
         bool m_lazy_load;
 
       public:
-        Reader(std::shared_ptr<std::istream> is, bool allow_any_explicit_vr = false, bool lazy_load = false);
+        Reader(std::shared_ptr<std::istream> is, bool allow_any_explicit_vr = false, bool lazy_load = true);
 
         RawReader& raw_reader();
 

--- a/include/vega/dicom/reader.h
+++ b/include/vega/dicom/reader.h
@@ -63,6 +63,7 @@ namespace vega {
 
       private:
         void read_data_element_undefined_sequence(std::shared_ptr<DataElement> element);
+        void read_data_element_value_field(std::shared_ptr<DataElement> element);
     };
   }
 }

--- a/include/vega/dicom/reader.h
+++ b/include/vega/dicom/reader.h
@@ -60,6 +60,11 @@ namespace vega {
         std::streampos eof_pos() const;
         void seek_pos(std::streampos pos);
         void seek_delta(std::streampos delta);
+
+      private:
+        void read_data_element_finite_sequence(std::shared_ptr<DataElement> element);
+        void read_data_element_undefined_sequence(std::shared_ptr<DataElement> element);
+        void read_data_element_value_field(std::shared_ptr<DataElement> element);
     };
   }
 }

--- a/src/vega/dicom/data_element.cpp
+++ b/src/vega/dicom/data_element.cpp
@@ -94,7 +94,7 @@ namespace vega {
       }
     }
 
-    void DataElement::set_value_field(std::shared_ptr<Reader> reader, std::streampos start) {
+    void DataElement::set_value_field(const std::shared_ptr<Reader>& reader, const std::streampos& start) {
       m_reader = reader;
       m_start = start;
     }
@@ -117,10 +117,11 @@ namespace vega {
     const std::weak_ptr<DataSet>& DataElement::parent() const { return m_parent; }
     std::weak_ptr<DataSet>& DataElement::parent() { return m_parent; }
 
-    const std::vector<std::shared_ptr<DataSet>>& DataElement::data_sets() const { return m_data_sets; }
-    std::vector<std::shared_ptr<DataSet>>& DataElement::data_sets() { return m_data_sets; }
+    const std::vector<std::shared_ptr<DataSet>>& DataElement::data_sets() const { lazy_load(); return m_data_sets; }
+    std::vector<std::shared_ptr<DataSet>>& DataElement::data_sets() { lazy_load(); return m_data_sets; }
 
     std::string DataElement::str() const {
+      lazy_load();
       return m_manipulator->str();
     }
 
@@ -245,6 +246,7 @@ namespace vega {
     void DataElement::lazy_load() const {
       if (!m_reader) return;
 
+      auto current = m_reader->tell();
       m_reader->seek_pos(m_start);
 
       if (this->is_sequence()) {
@@ -259,6 +261,7 @@ namespace vega {
         this->read_value_field();
       }
 
+      m_reader->seek_pos(current);
       m_reader = nullptr;
     }
 

--- a/src/vega/dicom/data_element.cpp
+++ b/src/vega/dicom/data_element.cpp
@@ -244,6 +244,11 @@ namespace vega {
     }
 
     void DataElement::lazy_load() const {
+      // Can definitely skip lazy loading if no reader
+      if (!m_reader) return;
+      std::lock_guard<std::mutex> lock(m_mutex);
+
+      // Second return check because reader might have been set to nullptr before the mutex was locked
       if (!m_reader) return;
       auto reader = m_reader;
       m_reader = nullptr;

--- a/src/vega/dicom/data_element.cpp
+++ b/src/vega/dicom/data_element.cpp
@@ -85,6 +85,10 @@ namespace vega {
       }
     }
 
+    std::shared_ptr<DataElement> DataElement::get_shared_ptr() {
+      return shared_from_this();
+    }
+
     const std::shared_ptr<const dictionary::Page>& DataElement::page() const { return m_page; }
     void DataElement::set_page(std::shared_ptr<const dictionary::Page> page) { m_page = page; }
 

--- a/src/vega/dicom/data_set.cpp
+++ b/src/vega/dicom/data_set.cpp
@@ -11,6 +11,10 @@ namespace vega {
         m_private_owner_blocks(std::make_shared<dictionary::PrivateOwnerBlocks>())
     {}
 
+    std::shared_ptr<DataSet> DataSet::get_shared_ptr() {
+      return shared_from_this();
+    }
+
     const DataSet::length_type DataSet::UNDEFINED_LENGTH = 0xFFFFFFFF;
 
     DataSet::iterator::iterator(DataSet::iterator::iterator_type it)

--- a/src/vega/dicom/data_set.cpp
+++ b/src/vega/dicom/data_set.cpp
@@ -11,10 +11,6 @@ namespace vega {
         m_private_owner_blocks(std::make_shared<dictionary::PrivateOwnerBlocks>())
     {}
 
-    std::shared_ptr<DataSet> DataSet::get_shared_ptr() {
-      return shared_from_this();
-    }
-
     const DataSet::length_type DataSet::UNDEFINED_LENGTH = 0xFFFFFFFF;
 
     DataSet::iterator::iterator(DataSet::iterator::iterator_type it)

--- a/src/vega/dicom/file.cpp
+++ b/src/vega/dicom/file.cpp
@@ -19,19 +19,19 @@ namespace vega {
       return v;
     }
 
-    File::File(const std::string& file_name, bool allow_any_explicit_vr)
+    File::File(const std::string& file_name, bool allow_any_explicit_vr, bool lazy_load)
       :
-        File(std::make_shared<std::ifstream>(file_name, std::ifstream::binary), allow_any_explicit_vr)
+        File(std::make_shared<std::ifstream>(file_name, std::ifstream::binary), allow_any_explicit_vr, lazy_load)
     {}
 
-    File::File(std::shared_ptr<std::istream> is, bool allow_any_explicit_vr)
+    File::File(std::shared_ptr<std::istream> is, bool allow_any_explicit_vr, bool lazy_load)
       :
         m_data_set(std::make_shared<DataSet>())
     {
       if (!is || !*is) {
         throw vega::Exception("Invalid input stream");
       }
-      auto reader = std::make_shared<Reader>(is, allow_any_explicit_vr);
+      auto reader = std::make_shared<Reader>(is, allow_any_explicit_vr, lazy_load);
 
       m_preamble = std::make_shared<Preamble>(*reader);
 

--- a/src/vega/dicom/reader.cpp
+++ b/src/vega/dicom/reader.cpp
@@ -31,6 +31,10 @@ namespace vega {
       return m_raw_reader.tell();
     }
 
+    std::streampos Reader::eof_pos() const {
+      return m_raw_reader.eof_pos();
+    }
+
     void Reader::seek_pos(std::streampos pos) {
       m_raw_reader.seek_pos(pos);
     }
@@ -40,7 +44,7 @@ namespace vega {
     }
 
     bool Reader::eof() {
-      return this->tell() < 0 || this->tell() >= m_raw_reader.eof_pos();
+      return this->tell() < 0 || this->tell() >= this->eof_pos();
     }
 
     void Reader::rewind() {
@@ -101,7 +105,7 @@ namespace vega {
           " cur_pos=" +
           std::to_string(this->tell()) +
           " eof=" +
-          std::to_string(m_raw_reader.eof_pos())
+          std::to_string(this->eof_pos())
         );
       }
 

--- a/src/vega/dicom/reader.cpp
+++ b/src/vega/dicom/reader.cpp
@@ -15,6 +15,10 @@ namespace vega {
     {
     }
 
+    std::shared_ptr<Reader> Reader::get_shared_ptr() {
+      return shared_from_this();
+    }
+
     RawReader& Reader::raw_reader() {
       return m_raw_reader;
     }


### PR DESCRIPTION
Now DICOM files will only be partially read in, and data elements that are requested will be loaded from the file on the fly.  For operations that only need a small number of elements from a DICOM file, this should offer speed up.

I wrote a benchmark to see the performance changes.  The scenarios are as follows:
- Lazy load the file, then read the patient name.
- Fully load the file, then read the patient name.
- Lazy load the file, then access the content of everything.
- Fully load the file, then access the content of everything.

```
➜  build git:(lazy_loading) ✗ cmake .. && make -j4 main && ./main --benchmark_repetitions=5
-- Configuring done
-- Generating done
-- Build files have been written to: /home/chris/cpp/vega/build
[ 98%] Built target vega_dev
[100%] Built target main
2018-05-22 12:25:54
Running ./main
Run on (4 X 3100 MHz CPU s)
CPU Caches:
  L1 Data 32K (x2)
  L1 Instruction 32K (x2)
  L2 Unified 256K (x2)
  L3 Unified 4096K (x1)
***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
------------------------------------------------------------------------
Benchmark                                 Time           CPU Iterations
------------------------------------------------------------------------
BM_LazyLoadGetPatientName_mean       115591 ns     115119 ns       5399
BM_LazyLoadGetPatientName_median     115899 ns     115398 ns       5399
BM_LazyLoadGetPatientName_stddev       1878 ns       1807 ns       5399
BM_FullLoadGetPatientName_mean    133699493 ns  133638321 ns          5
BM_FullLoadGetPatientName_median  131705506 ns  131670004 ns          5
BM_FullLoadGetPatientName_stddev    4459700 ns    4451296 ns          5
BM_LazyLoadAccessAll_mean         143538686 ns  143418592 ns          5
BM_LazyLoadAccessAll_median       139437036 ns  139375440 ns          5
BM_LazyLoadAccessAll_stddev         9246418 ns    9096273 ns          5
BM_FullLoadAccessAll_mean         134245146 ns  133996469 ns          5
BM_FullLoadAccessAll_median       135072971 ns  134736287 ns          5
BM_FullLoadAccessAll_stddev         3296564 ns    3297149 ns          5
```

Notice that when you only access a small part of the DICOM file, it is 3 orders of magnitude faster to lazy load it.  Furthermore, there is only a 10% overhead caused by lazy loading when you access everything.  So by default, we will set lazy_load to be `true`, but it is still possible to do a full load when you intend to read all the data anyway (e.g. reading CT data).

Running the full load benchmarks on master gives the following values, which shows that there is negligible change when doing full loads:

```
BM_FullLoadGetPatientName_mean    136796482 ns  136252871 ns          5
BM_FullLoadAccessAll_mean         134509279 ns  134107316 ns          5
```

Here is the benchmark code:

```c++
#include <string>
#include <memory>
#include <iostream>
#include <chrono>
#include <benchmark/benchmark.h>

#include "vega/dictionary/dictionary.h"
#include "vega/dicom/file.h"

const std::string dictionary{"/home/chris/cpp/vega/test/dictionary.txt"};
const std::string filename{"/home/chris/cpp/vega/test/data/0522c0002/RS.1.2.246.352.71.4.4061753534.432046.20170517120331.dcm"};

static void BM_LazyLoadGetPatientName(benchmark::State& state) {
  vega::dictionary::Dictionary::set_dictionary(dictionary);
  for (auto _ : state) {
    vega::dicom::File file(filename, false, true);
    auto name = file.data_set()->element<vega::dictionary::PatientName>();
  }
}
BENCHMARK(BM_LazyLoadGetPatientName);


static void BM_FullLoadGetPatientName(benchmark::State& state) {
  vega::dictionary::Dictionary::set_dictionary(dictionary);
  for (auto _ : state) {
    vega::dicom::File file(filename, false, false);
    auto name = file.data_set()->element<vega::dictionary::PatientName>();
  }
}
BENCHMARK(BM_FullLoadGetPatientName);

void access_all_data_element(const std::shared_ptr<vega::dicom::DataElement>& data_element);
void access_all_data_set(const std::shared_ptr<vega::dicom::DataSet>& data_set);

void access_all_data_element(const std::shared_ptr<vega::dicom::DataElement>& data_element) {
  if (data_element->is_sequence()) {
    for (const auto& data_set : data_element->data_sets()) {
      access_all_data_set(data_set);
    }
  }
  else {
    auto manipulator = data_element->manipulator();
  }
}

void access_all_data_set(const std::shared_ptr<vega::dicom::DataSet>& data_set) {
  for (const auto& data_element : *data_set) {
    access_all_data_element(data_element);
  }
}

static void BM_LazyLoadAccessAll(benchmark::State& state) {
  vega::dictionary::Dictionary::set_dictionary(dictionary);
  for (auto _ : state) {
    vega::dicom::File file(filename, false, true);
    access_all_data_set(file.data_set());
  }
}
BENCHMARK(BM_LazyLoadAccessAll);

static void BM_FullLoadAccessAll(benchmark::State& state) {
  vega::dictionary::Dictionary::set_dictionary(dictionary);
  for (auto _ : state) {
    vega::dicom::File file(filename, false, false);
    access_all_data_set(file.data_set());
  }
}
BENCHMARK(BM_FullLoadAccessAll);

BENCHMARK_MAIN();
```