### PR TITLE
Remove undefined lengths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,8 @@ SET_TARGET_PROPERTIES(vega-bin PROPERTIES OUTPUT_NAME ${PROJECT_NAME})
 target_link_libraries(vega-bin ${PROJECT_NAME} z)
 install(TARGETS vega-bin RUNTIME DESTINATION bin)
 
+install(FILES "test/dictionary.txt" DESTINATION share/vega)
+
 # Test command
 if (GTest_FOUND)
   include_directories(${GTest_INCLUDE_DIRS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,14 +35,16 @@ install (DIRECTORY include/${PROJECT_NAME} DESTINATION include)
 # sudo cp *.a /usr/lib
 find_package(GTest REQUIRED)
 
-add_executable(vega_dev-bin "src/main.cpp")
-target_link_libraries(vega_dev-bin ${PROJECT_NAME}_dev z)
+add_executable(main "src/main.cpp")
+target_link_libraries(main ${PROJECT_NAME}_dev z)
 
+# Installing `vega` binary to `/usr/local/bin/vega`
 add_executable(vega-bin "src/main.cpp")
 SET_TARGET_PROPERTIES(vega-bin PROPERTIES OUTPUT_NAME ${PROJECT_NAME})
 target_link_libraries(vega-bin ${PROJECT_NAME} z)
 install(TARGETS vega-bin RUNTIME DESTINATION bin)
 
+# Installing vega dictionary file to `/usr/local/share/vega/dictionary.txt`
 install(FILES "test/dictionary.txt" DESTINATION share/vega)
 
 # Test command

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,8 +35,13 @@ install (DIRECTORY include/${PROJECT_NAME} DESTINATION include)
 # sudo cp *.a /usr/lib
 find_package(GTest REQUIRED)
 
-add_executable(main "src/main.cpp")
-target_link_libraries(main ${PROJECT_NAME}_dev z)
+add_executable(vega_dev-bin "src/main.cpp")
+target_link_libraries(vega_dev-bin ${PROJECT_NAME}_dev z)
+
+add_executable(vega-bin "src/main.cpp")
+SET_TARGET_PROPERTIES(vega-bin PROPERTIES OUTPUT_NAME ${PROJECT_NAME})
+target_link_libraries(vega-bin ${PROJECT_NAME} z)
+install(TARGETS vega-bin RUNTIME DESTINATION bin)
 
 # Test command
 if (GTest_FOUND)

--- a/README.md
+++ b/README.md
@@ -27,6 +27,26 @@ To compile code that uses this library, you should link the library, the zlib li
 clang++ --std=c++11 -lvega -lz my_code.cpp -o my_code
 ```
 
+## Installing `vega` binary
+
+This library comes packaged with a runtime executable `vega` that can is installed by `make install` to `/usr/local/bin/vega`.
+It reads from the dictionary file installed to `/usr/local/share/vega/dictionary.txt`, and can be used to process DICOM files in the terminal.
+A DICOM file can either be piped in as STDIN from a DICOM file,
+```
+cat my_dicom_file.dcm | vega
+```
+or it can be specified in an input flag
+```
+vega --input=my_dicom_file.dcm
+```
+For output, `vega` supports 3 file formats: `".dcm"` for DICOM format, `".json"` for JSON file format, and `".txt"` for human-readable plain text files.
+If `--output` is just equal to the extension (e.g. `--output=json`), then the DICOM file will be printed to STDOUT in that format.
+If `--output` is a full filename with the relevant extension, then it will be wrote to that file.
+
+The `vega` binary also supports options to modify the DICOM file before outputting.
+Currently the only implemented option is `--remove_undefined_lengths` which forces the output file to have no data elements with undefined lengths.
+Eventually this binary will also support DICOM file anonymization.
+
 ## Reading/writing files
 
 Here is a simple example of using the library to read a file in and print a string representation of the content to standard out.

--- a/include/argh/LICENSE
+++ b/include/argh/LICENSE
@@ -1,0 +1,26 @@
+Copyright (c) 2016, Adi Shavit 
+All rights reserved. 
+
+Redistribution and use in source and binary forms, with or without 
+modification, are permitted provided that the following conditions are met: 
+
+ * Redistributions of source code must retain the above copyright notice, 
+   this list of conditions and the following disclaimer. 
+ * Redistributions in binary form must reproduce the above copyright 
+   notice, this list of conditions and the following disclaimer in the 
+   documentation and/or other materials provided with the distribution. 
+ * Neither the name of  nor the names of its contributors may be used to 
+   endorse or promote products derived from this software without specific 
+   prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+POSSIBILITY OF SUCH DAMAGE. 

--- a/include/argh/argh.h
+++ b/include/argh/argh.h
@@ -1,0 +1,402 @@
+#pragma once
+
+#include <algorithm>
+#include <sstream>
+#include <string>
+#include <vector>
+#include <set>
+#include <map>
+#include <cassert>
+
+namespace argh
+{
+   // Terminology:
+   // A command line is composed of 2 types of args:
+   // 1. Positional args, i.e. free standing values
+   // 2. Options: args beginning with '-'. We identify two kinds:
+   //    2.1: Flags: boolean options =>  (exist ? true : false)
+   //    2.2: Parameters: a name followed by a non-option value
+
+#if !defined(__GNUC__) || (__GNUC__ >= 5)
+   using string_stream = std::istringstream;
+#else
+    // Until GCC 5, istringstream did not have a move constructor.
+    // stringstream_proxy is used instead, as a workaround.
+   class stringstream_proxy
+   {
+   public:
+      stringstream_proxy() = default;
+
+      // Construct with a value.
+      stringstream_proxy(std::string const& value) :
+         stream_(value)
+      {}
+
+      // Copy constructor.
+      stringstream_proxy(const stringstream_proxy& other) :
+         stream_(other.stream_.str())
+      {
+         stream_.setstate(other.stream_.rdstate());
+      }
+
+      void setstate(std::ios_base::iostate state) { stream_.setstate(state); }
+
+      // Stream out the value of the parameter.
+      // If the conversion was not possible, the stream will enter the fail state,
+      // and operator bool will return false.
+      template<typename T>
+      stringstream_proxy& operator >> (T& thing)
+      {
+         stream_ >> thing;
+         return *this;
+      }
+
+
+      // Get the string value.
+      std::string str() const { return stream_.str(); }
+
+      std::stringbuf* rdbuf() const { return stream_.rdbuf(); }
+
+      // Check the state of the stream. 
+      // False when the most recent stream operation failed
+      operator bool() const { return !!stream_; }
+
+      ~stringstream_proxy() = default;
+   private:
+      std::istringstream stream_;
+   };
+   using string_stream = stringstream_proxy;
+#endif
+
+   class parser
+   {
+   public:
+      enum Mode { PREFER_FLAG_FOR_UNREG_OPTION = 1 << 0,
+                  PREFER_PARAM_FOR_UNREG_OPTION = 1 << 1,
+                  NO_SPLIT_ON_EQUALSIGN = 1 << 2,
+                  SINGLE_DASH_IS_MULTIFLAG = 1 << 3,
+                };
+
+      parser() = default;
+
+      parser(std::initializer_list<char const* const> pre_reg_names)
+      {  add_params(pre_reg_names); }
+
+      parser(const char* const argv[], int mode = PREFER_FLAG_FOR_UNREG_OPTION)
+      {  parse(argv, mode); }
+
+      parser(int argc, const char* const argv[], int mode = PREFER_FLAG_FOR_UNREG_OPTION)
+      {  parse(argc, argv, mode); }
+
+      void add_param(std::string const& name);
+      void add_params(std::initializer_list<char const* const> init_list);
+
+      void parse(const char* const argv[], int mode = PREFER_FLAG_FOR_UNREG_OPTION);
+      void parse(int argc, const char* const argv[], int mode = PREFER_FLAG_FOR_UNREG_OPTION);
+
+      std::multiset<std::string>          const& flags()    const { return flags_;    }
+      std::map<std::string, std::string>  const& params()   const { return params_;   }
+      std::vector<std::string>            const& pos_args() const { return pos_args_; }
+
+      // begin() and end() for using range-for over positional args.
+      std::vector<std::string>::const_iterator begin() const { return pos_args_.cbegin(); }
+      std::vector<std::string>::const_iterator end()   const { return pos_args_.cend();   }
+      size_t size()                                    const { return pos_args_.size();   }
+
+      //////////////////////////////////////////////////////////////////////////
+      // Accessors
+
+      // flag (boolean) accessors: return true if the flag appeared, otherwise false.
+      bool operator[](std::string const& name) const;
+
+      // multiple flag (boolean) accessors: return true if at least one of the flag appeared, otherwise false.
+      bool operator[](std::initializer_list<char const* const> init_list) const;
+
+      // returns positional arg string by order. Like argv[] but without the options
+      std::string const& operator[](size_t ind) const;
+
+      // returns a std::istream that can be used to convert a positional arg to a typed value.
+      string_stream operator()(size_t ind) const;
+
+      // same as above, but with a default value in case the arg is missing (index out of range).
+      template<typename T>
+      string_stream operator()(size_t ind, T&& def_val) const;
+
+      // parameter accessors, give a name get an std::istream that can be used to convert to a typed value.
+      // call .str() on result to get as string
+      string_stream operator()(std::string const& name) const;
+
+      // accessor for a parameter with multiple names, give a list of names, get an std::istream that can be used to convert to a typed value.
+      // call .str() on result to get as string
+      // returns the first value in the list to be found.
+      string_stream operator()(std::initializer_list<char const* const> init_list) const;
+
+      // same as above, but with a default value in case the param was missing.
+      // Non-string def_val types must have an operator<<() (output stream operator)
+      // If T only has an input stream operator, pass the string version of the type as in "3" instead of 3.
+      template<typename T>
+      string_stream operator()(std::string const& name, T&& def_val) const;
+
+      // same as above but for a list of names. returns the first value to be found.
+      template<typename T>
+      string_stream operator()(std::initializer_list<char const* const> init_list, T&& def_val) const;
+
+   private:
+      string_stream bad_stream() const;
+      std::string trim_leading_dashes(std::string const& name) const;
+      bool is_number(std::string const& arg) const;
+      bool is_option(std::string const& arg) const;
+      bool got_flag(std::string const& name) const;
+
+   private:
+      std::vector<std::string> args_;
+      std::map<std::string, std::string> params_;
+      std::vector<std::string> pos_args_;
+      std::multiset<std::string> flags_;
+      std::set<std::string> registeredParams_;
+      std::string empty_;
+   };
+
+
+   //////////////////////////////////////////////////////////////////////////
+
+   inline void parser::parse(const char * const argv[], int mode)
+   {
+      int argc = 0;
+      for (auto argvp = argv; *argvp; ++argc, ++argvp);
+      parse(argc, argv, mode);
+   }
+
+   //////////////////////////////////////////////////////////////////////////
+
+   inline void parser::parse(int argc, const char* const argv[], int mode /*= PREFER_FLAG_FOR_UNREG_OPTION*/)
+   {
+      // convert to strings
+      args_.resize(argc);
+      std::transform(argv, argv + argc, args_.begin(), [](const char* const arg) { return arg;  });
+
+      // parse line
+      for (auto i = 0u; i < args_.size(); ++i)
+      {
+         if (!is_option(args_[i]))
+         {
+            pos_args_.emplace_back(args_[i]);
+            continue;
+         }
+
+         auto name = trim_leading_dashes(args_[i]);
+
+         if (!(mode & NO_SPLIT_ON_EQUALSIGN))
+         {
+            auto equalPos = name.find('=');
+            if (equalPos != std::string::npos)
+            {
+               params_.insert({ name.substr(0, equalPos), name.substr(equalPos + 1) });
+               continue;
+            }
+         }
+
+         // if the option is unregistered and should be a multi-flag
+         if (1 == (args_[i].size() - name.size()) &&                  // single dash
+            argh::parser::SINGLE_DASH_IS_MULTIFLAG & mode &&         // multi-flag mode
+            registeredParams_.find(name) == registeredParams_.end()) // unregistered
+         {
+            for (auto const& c : name)
+            {
+               flags_.emplace(std::string{ c });
+            }
+         }
+
+         // any potential option will get as its value the next arg, unless that arg is an option too
+         // in that case it will be determined a flag.
+         if (i == args_.size() - 1 || is_option(args_[i + 1]))
+         {
+            flags_.emplace(name);
+            continue;
+         }
+
+         // if 'name' is a pre-registered option, then the next arg cannot be a free parameter to it is skipped
+         // otherwise we have 2 modes:
+         // PREFER_FLAG_FOR_UNREG_OPTION: a non-registered 'name' is determined a flag. 
+         //                               The following value (the next arg) will be a free parameter.
+         //
+         // PREFER_PARAM_FOR_UNREG_OPTION: a non-registered 'name' is determined a parameter, the next arg
+         //                                will be the value of that option.
+
+         if (registeredParams_.find(name) != registeredParams_.end() ||
+            argh::parser::PREFER_PARAM_FOR_UNREG_OPTION & mode)
+         {
+            params_.insert({ name, args_[i + 1] });
+            ++i; // skip next value, it is not a free parameter
+            continue;
+         }
+
+         if (argh::parser::PREFER_FLAG_FOR_UNREG_OPTION & mode)
+            flags_.emplace(name);
+      };
+   }
+
+   //////////////////////////////////////////////////////////////////////////
+
+   inline string_stream parser::bad_stream() const
+   {
+      string_stream bad;
+      bad.setstate(std::ios_base::failbit);
+      return bad;
+   }
+
+   //////////////////////////////////////////////////////////////////////////
+
+   inline bool parser::is_number(std::string const& arg) const
+   {
+      // inefficient but simple way to determine if a string is a number (which can start with a '-')
+      std::istringstream istr(arg);
+      double number;
+      istr >> number;
+      return !(istr.fail() || istr.bad());
+   }
+
+   //////////////////////////////////////////////////////////////////////////
+
+   inline bool parser::is_option(std::string const& arg) const
+   {
+      assert(0 != arg.size());
+      if (is_number(arg))
+         return false;
+      return '-' == arg[0];
+   }
+
+   //////////////////////////////////////////////////////////////////////////
+
+   inline std::string parser::trim_leading_dashes(std::string const& name) const
+   {
+      auto pos = name.find_first_not_of('-');
+      return std::string::npos != pos ? name.substr(pos) : name;
+   }
+
+   //////////////////////////////////////////////////////////////////////////
+
+   inline bool argh::parser::got_flag(std::string const& name) const
+   {
+      return flags_.end() != flags_.find(trim_leading_dashes(name));
+   }
+
+   //////////////////////////////////////////////////////////////////////////
+
+   inline bool parser::operator[](std::string const& name) const
+   {
+      return got_flag(name);
+   }
+
+   //////////////////////////////////////////////////////////////////////////
+
+   inline bool parser::operator[](std::initializer_list<char const* const> init_list) const
+   {
+      return std::any_of(init_list.begin(), init_list.end(), [&](char const* const name) { return got_flag(name); });
+   }
+
+   //////////////////////////////////////////////////////////////////////////
+
+   inline std::string const& parser::operator[](size_t ind) const
+   {
+      if (ind < pos_args_.size())
+         return pos_args_[ind];
+      return empty_;
+   }
+
+   //////////////////////////////////////////////////////////////////////////
+
+   inline string_stream parser::operator()(std::string const& name) const
+   {
+      auto optIt = params_.find(trim_leading_dashes(name));
+      if (params_.end() != optIt)
+         return string_stream(optIt->second);
+      return bad_stream();
+   }
+
+   //////////////////////////////////////////////////////////////////////////
+
+   inline string_stream parser::operator()(std::initializer_list<char const* const> init_list) const
+   {
+      for (auto& name : init_list)
+      {
+         auto optIt = params_.find(trim_leading_dashes(name));
+         if (params_.end() != optIt)
+            return string_stream(optIt->second);
+      }
+      return bad_stream();
+   }
+
+   //////////////////////////////////////////////////////////////////////////
+
+   template<typename T>
+   string_stream parser::operator()(std::string const& name, T&& def_val) const
+   {
+      auto optIt = params_.find(trim_leading_dashes(name));
+      if (params_.end() != optIt)
+         return string_stream(optIt->second);
+
+      std::ostringstream ostr;
+      ostr << def_val;
+      return string_stream(ostr.str()); // use default
+   }
+
+   //////////////////////////////////////////////////////////////////////////
+
+   // same as above but for a list of names. returns the first value to be found.
+   template<typename T>
+   string_stream parser::operator()(std::initializer_list<char const* const> init_list, T&& def_val) const
+   {
+      for (auto& name : init_list)
+      {
+         auto optIt = params_.find(trim_leading_dashes(name));
+         if (params_.end() != optIt)
+            return string_stream(optIt->second);
+      }      
+      std::ostringstream ostr;
+      ostr << def_val;
+      return string_stream(ostr.str()); // use default
+   }
+
+   //////////////////////////////////////////////////////////////////////////
+
+   inline string_stream parser::operator()(size_t ind) const
+   {
+      if (pos_args_.size() <= ind)
+         return bad_stream();
+
+      return string_stream(pos_args_[ind]);
+   }
+
+   //////////////////////////////////////////////////////////////////////////
+
+   template<typename T>
+   string_stream parser::operator()(size_t ind, T&& def_val) const
+   {
+      if (pos_args_.size() <= ind)
+      {
+         std::ostringstream ostr;
+         ostr << def_val;
+         return string_stream(ostr.str());
+      }
+
+      return string_stream(pos_args_[ind]);
+   }
+
+   //////////////////////////////////////////////////////////////////////////
+
+   inline void parser::add_param(std::string const& name)
+   {
+      registeredParams_.insert(trim_leading_dashes(name));
+   }
+
+   //////////////////////////////////////////////////////////////////////////
+
+   inline void parser::add_params(std::initializer_list<char const* const> init_list)
+   {
+      for (auto& name : init_list)
+         registeredParams_.insert(trim_leading_dashes(name));
+   }
+}
+
+

--- a/include/vega/controller.h
+++ b/include/vega/controller.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "argh/argh.h"
+
+namespace vega {
+  class Controller {
+    private:
+      argh::parser parser_;
+
+      std::string input_file_;
+      std::string output_file_;
+
+      enum class Operation {
+        REMOVE_UNDEFINED_LENGTHS
+      };
+
+      std::vector<Operation> operations_;
+
+    public:
+      Controller(int argc, char* argv[]);
+
+      void run() const;
+  };
+}

--- a/include/vega/dicom/element.h
+++ b/include/vega/dicom/element.h
@@ -75,10 +75,10 @@ namespace vega {
         }
 
         const Tag& tag() const;
-        Tag& tag();
-
         const VR& vr() const;
-        VR& vr();
+
+        DataElementHeader::length_type& length();
+        const DataElementHeader::length_type& length() const;
     };
   }
 }

--- a/include/vega/dicom/element_impl.h
+++ b/include/vega/dicom/element_impl.h
@@ -34,11 +34,12 @@ namespace vega {
     const Tag& Element<T>::tag() const { return m_data_element->tag(); }
 
     template <typename T>
-    Tag& Element<T>::tag() { return m_data_element->tag(); }
+    const VR& Element<T>::vr() const { return m_data_element->vr(); }
 
     template <typename T>
-    const VR& Element<T>::vr() const { return m_data_element->vr(); }
+    const DataElementHeader::length_type& Element<T>::length() const { return m_data_element->length(); }
+
     template <typename T>
-    VR& Element<T>::vr() { return m_data_element->vr(); }
+    DataElementHeader::length_type& Element<T>::length() { return m_data_element->length(); }
   }
 }

--- a/include/vega/dicom/file.h
+++ b/include/vega/dicom/file.h
@@ -73,6 +73,10 @@ namespace vega {
         const std::shared_ptr<DataSet>& data_set() const;
 
         /**
+         * Writes this DICOM file to STDOUT
+         */
+        void write() const;
+        /**
          * Writes this DICOM file to the given \p filename.
          */
         void write(const std::string& filename) const;
@@ -84,6 +88,10 @@ namespace vega {
          */
         void write(std::shared_ptr<std::ostream> os) const;
 
+        /**
+         * Writes this DICOM file in JSON format to STDOUT
+         */
+        void write_json() const;
         /**
          * Writes this DICOM file in JSON format to the given \p filename.
          */

--- a/include/vega/undefined_length_remover.h
+++ b/include/vega/undefined_length_remover.h
@@ -1,0 +1,20 @@
+#pragma once
+
+namespace vega {
+  namespace dicom {
+    class File;
+    class DataSet;
+    class DataElement;
+  }
+
+  class UndefinedLengthRemover {
+    public:
+      UndefinedLengthRemover();
+
+      void remove_undefined_lengths(dicom::File& file) const;
+      void remove_undefined_lengths(dicom::DataSet& data_set) const;
+
+    private:
+      bool remove_undefined_lengths(dicom::DataElement& data_element) const;
+  };
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,9 +2,10 @@
 #include <memory>
 
 #include "vega/dictionary/dictionary.h"
-#include "vega/dicom/file.h"
+#include "vega/controller.h"
 
-int main() {
-  vega::dictionary::Dictionary::set_dictionary("/home/chris/cpp/vega/test/dictionary.txt");
-  // FIXME: do something
+int main(int argc, char* argv[]) {
+  vega::dictionary::Dictionary::set_dictionary(std::getenv("VEGA_DICTIONARY"));
+  vega::Controller controller(argc, argv);
+  controller.run();
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,7 +5,7 @@
 #include "vega/controller.h"
 
 int main(int argc, char* argv[]) {
-  vega::dictionary::Dictionary::set_dictionary(std::getenv("VEGA_DICTIONARY"));
+  vega::dictionary::Dictionary::set_dictionary("/usr/local/share/vega/dictionary.txt");
   vega::Controller controller(argc, argv);
   controller.run();
 }

--- a/src/vega/controller.cpp
+++ b/src/vega/controller.cpp
@@ -1,0 +1,99 @@
+#include "vega/controller.h"
+
+#include "vega/dicom/file.h"
+#include "vega/undefined_length_remover.h"
+
+#include <fstream>
+#include <iostream>
+#include <algorithm>
+#include <string>
+
+namespace vega {
+  Controller::Controller(int argc, char* argv[])
+    : parser_(argc, argv)
+  {
+    if (!(parser_({"-i", "--input"}) >> input_file_)) {
+      input_file_ = "";
+    }
+    if (!(parser_({"-o", "--output"}) >> output_file_)) {
+      output_file_ = "";
+    }
+
+    if (parser_["remove_undefined_lengths"]) {
+      operations_.push_back(Operation::REMOVE_UNDEFINED_LENGTHS);
+    }
+  }
+
+  void Controller::run() const {
+    std::shared_ptr<dicom::File> file;
+
+    if (input_file_.empty()) {
+      // Read DICOM file from STDIN (piped input)
+      auto ss = std::make_shared<std::stringstream>();
+      *ss << std::cin.rdbuf();
+      file = std::make_shared<dicom::File>(ss);
+    }
+    else {
+      // Read from filename
+      file = std::make_shared<dicom::File>(input_file_);
+    }
+
+    for (const auto& operation : operations_) {
+      switch (operation) {
+        case Operation::REMOVE_UNDEFINED_LENGTHS:
+          {
+            UndefinedLengthRemover remover{};
+            remover.remove_undefined_lengths(*file->data_set());
+          }
+          break;
+      }
+    }
+
+    std::shared_ptr<std::ostream> output;
+
+    if (output_file_.empty()) {
+      // Write file to STDOUT (assume in DICOM format)
+      file->write();
+    }
+    else {
+      // Write to file
+      // Determine which format (DICOM, JSON, TXT)
+
+      std::string lowercase_output;
+      std::transform(output_file_.begin(), output_file_.end(), lowercase_output.begin(), ::tolower);
+
+      // DICOM format to STDOUT
+      if (output_file_ == "dcm" || output_file_ == "dicom") {
+        file->write();
+      }
+      else if (output_file_ == "json") {
+        file->write_json();
+      }
+      else if (output_file_ == "txt" || output_file_ == "text") {
+        Formatter f(std::cout);
+        file->data_set()->log(f);
+      }
+      else {
+        // Check output file format
+        std::string dcm_ending(".dcm");
+        std::string json_ending(".json");
+        std::string txt_ending(".txt");
+
+        if (std::equal(dcm_ending.rbegin(), dcm_ending.rend(), output_file_.rbegin())) {
+          file->write(output_file_);
+        }
+        else if (std::equal(json_ending.rbegin(), json_ending.rend(), output_file_.rbegin())) {
+          file->write_json(output_file_);
+        }
+        else if (std::equal(txt_ending.rbegin(), txt_ending.rend(), output_file_.rbegin())) {
+          std::ofstream ofs(output_file_);
+          Formatter f(ofs);
+          file->data_set()->log(f);
+        }
+        else {
+          throw std::runtime_error("Unknown output file format");
+        }
+      }
+    }
+  }
+}

--- a/src/vega/controller.cpp
+++ b/src/vega/controller.cpp
@@ -30,9 +30,9 @@ namespace vega {
     std::shared_ptr<dicom::File> file;
 
     if (input_file_.empty()) {
-      if (isatty(fileno(stdin))) {
-        throw std::runtime_error("Cannot run on user input, please specify input file or pipe in DICOM file");
-      }
+      // Skip if no piped data
+      if (isatty(fileno(stdin))) return;
+
       // Read DICOM file from STDIN (piped input)
       auto ss = std::make_shared<std::stringstream>();
       *ss << std::cin.rdbuf();

--- a/src/vega/controller.cpp
+++ b/src/vega/controller.cpp
@@ -7,6 +7,8 @@
 #include <iostream>
 #include <algorithm>
 #include <string>
+#include <unistd.h>
+#include <stdio.h>
 
 namespace vega {
   Controller::Controller(int argc, char* argv[])
@@ -28,6 +30,9 @@ namespace vega {
     std::shared_ptr<dicom::File> file;
 
     if (input_file_.empty()) {
+      if (isatty(fileno(stdin))) {
+        throw std::runtime_error("Cannot run on user input, please specify input file or pipe in DICOM file");
+      }
       // Read DICOM file from STDIN (piped input)
       auto ss = std::make_shared<std::stringstream>();
       *ss << std::cin.rdbuf();

--- a/src/vega/dicom/file.cpp
+++ b/src/vega/dicom/file.cpp
@@ -123,6 +123,12 @@ namespace vega {
       return m_data_set;
     }
 
+    void File::write() const {
+      auto ss = std::make_shared<std::stringstream>();
+      write(ss);
+      std::cout << ss->str();
+    }
+
     void File::write(const std::string& filename) const {
       std::shared_ptr<std::ofstream> ofs(std::make_shared<std::ofstream>(filename, std::ofstream::binary));
       if (!ofs || !*ofs) {
@@ -160,6 +166,12 @@ namespace vega {
           writer->write_element(element);
         }
       }
+    }
+
+    void File::write_json() const {
+      auto ss = std::make_shared<std::stringstream>();
+      write_json(ss);
+      std::cout << ss->str();
     }
 
     void File::write_json(const std::string& filename) const {

--- a/src/vega/dicom/writer.cpp
+++ b/src/vega/dicom/writer.cpp
@@ -45,17 +45,17 @@ namespace vega {
           uint16_t zero = 0;
           /* std::cout << "Writer::write_element, 2 byte buffer" << std::endl; */
           prefix_bytes += m_raw_writer.write_from(zero);
-          length_pos = this->tell();
           length_bytes = sizeof(element->length());
           /* std::cout << "Writer::write_element, 4 byte length temp value " << element->length() << std::endl; */
+          length_pos = this->tell();
           prefix_bytes += m_raw_writer.write_from(element->length());
         }
         // Here we have 16 bit length field
         else {
           uint16_t length = element->length();
-          length_pos = this->tell();
           length_bytes = sizeof(length);
           /* std::cout << "Writer::write_element, 2 byte length temp value " << length << std::endl; */
+          length_pos = this->tell();
           prefix_bytes += m_raw_writer.write_from(length);
         }
       }
@@ -90,12 +90,15 @@ namespace vega {
         // Here we go back an retroactively record how many bytes we wrote
         std::streampos end_of_element = this->tell();
         this->seek_pos(length_pos);
-        if (length_bytes == 4) {
+        if (length_bytes == sizeof(value_length)) {
           /* std::cout << "Writer::write_element, writing correct 4 byte length " << value_length << std::endl; */
           m_raw_writer.write_from(value_length);
         }
         else {
           uint16_t l = value_length;
+          if (l < value_length) {
+            throw std::runtime_error("Error: encountered overflow when trying to write 2 byte length");
+          }
           /* std::cout << "Writer::write_element, writing correct 2 byte length " << l << std::endl; */
           m_raw_writer.write_from(l);
         }

--- a/src/vega/undefined_length_remover.cpp
+++ b/src/vega/undefined_length_remover.cpp
@@ -1,0 +1,34 @@
+#include "vega/undefined_length_remover.h"
+
+#include "vega/dicom/file.h"
+#include "vega/dicom/data_set.h"
+#include "vega/dicom/data_element.h"
+#include "vega/visitor.h"
+
+namespace vega {
+  UndefinedLengthRemover::UndefinedLengthRemover() {}
+
+  void UndefinedLengthRemover::remove_undefined_lengths(dicom::File& file) const {
+    remove_undefined_lengths(*file.data_set());
+  }
+
+  void UndefinedLengthRemover::remove_undefined_lengths(dicom::DataSet& data_set) const {
+    Visitor v {
+      [this](dicom::DataElement& data_element) -> bool {
+        return this->remove_undefined_lengths(data_element);
+      }
+    };
+
+    v.visit(data_set);
+  }
+
+  bool UndefinedLengthRemover::remove_undefined_lengths(dicom::DataElement& data_element) const {
+    if (data_element.is_undefined_length()) {
+      if (data_element.tag().is_private()) return true;
+
+      data_element.length() = 0;
+    }
+
+    return false;
+  }
+}

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -17,6 +17,7 @@
 #include "date_time_test.h"
 #include "json_test.h"
 #include "visitor_test.h"
+#include "undefined_length_remover_test.h"
 #include "dicom/data_element_test.h"
 #include "dicom/data_set_test.h"
 #include "dicom/sop_class_test.h"

--- a/test/undefined_length_remover_test.h
+++ b/test/undefined_length_remover_test.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include "test_helper.h"
+
+#include "vega/undefined_length_remover.h"
+
+using namespace vega;
+
+TEST(UndefinedLengthRemoverTest, test_undefined_length_remover) {
+  UndefinedLengthRemover remover{};
+
+  std::string filename = tests::path_to_file("data/undefined_SQ_rtdose.dcm");
+  dicom::File file_original(filename);
+
+  dicom::File file_modified(filename);
+  remover.remove_undefined_lengths(file_modified);
+
+  std::shared_ptr<std::stringstream> ss = std::make_shared<std::stringstream>();
+  file_modified.write(ss);
+  dicom::File file_copy(ss);
+
+  // Content unchanged
+  EXPECT_EQ(*file_original.data_set(), *file_copy.data_set());
+
+  /* (300C,0002) SQ "ReferencedRTPlanSequence" VM=1 (len=4294967295): */
+  /*   --- Data set 1/1 with 3 elements --- */
+  /*   (0008,1150) UI "ReferencedSOPClassUID" VM=1 (len=30): 1.2.840.10008.5.1.4.1.1.481.5 */
+  /*   (0008,1155) UI "ReferencedSOPInstanceUID" VM=1 (len=40): 1.2.3.4.5.6.7.8.9.0.1.2.3.4.5.6.7.8.9.4 */
+  /*   (300C,0020) SQ "ReferencedFractionGroupSequence" VM=1 (len=4294967295): */
+  /*     --- Data set 1/1 with 2 elements --- */
+  /*     (300C,0004) SQ "ReferencedBeamSequence" VM=1 (len=4294967295): */
+  /*       --- Data set 1/1 with 1 elements --- */
+  /*       (300C,0006) IS "ReferencedBeamNumber" VM=1 (len=2): 2 */
+  /*     (300C,0022) IS "ReferencedFractionGroupNumber" VM=1 (len=2): 1 */
+  /* (7FE0,0010) OW "PixelData" VM=1 (len=23217): Pixel Data (size 23217) */
+
+  EXPECT_EQ(file_original.data_set()->element<dictionary::ReferencedRTPlanSequence>()->length(), dicom::DataElementHeader::UNDEFINED_LENGTH);
+  EXPECT_NE(file_modified.data_set()->element<dictionary::ReferencedRTPlanSequence>()->length(), dicom::DataElementHeader::UNDEFINED_LENGTH);
+
+  EXPECT_EQ(
+      file_original.data_set()->element<dictionary::ReferencedRTPlanSequence>()->data_sets()[0]->element<dictionary::ReferencedFractionGroupSequence>()->length(),
+    dicom::DataElementHeader::UNDEFINED_LENGTH
+  );
+  EXPECT_NE(
+      file_modified.data_set()->element<dictionary::ReferencedRTPlanSequence>()->data_sets()[0]->element<dictionary::ReferencedFractionGroupSequence>()->length(),
+    dicom::DataElementHeader::UNDEFINED_LENGTH
+  );
+
+  EXPECT_EQ(
+      file_original.data_set()->element<dictionary::ReferencedRTPlanSequence>()->data_sets()[0]->element<dictionary::ReferencedFractionGroupSequence>()->data_sets()[0]->element<dictionary::ReferencedBeamSequence>()->length(),
+    dicom::DataElementHeader::UNDEFINED_LENGTH
+  );
+  EXPECT_NE(
+      file_modified.data_set()->element<dictionary::ReferencedRTPlanSequence>()->data_sets()[0]->element<dictionary::ReferencedFractionGroupSequence>()->data_sets()[0]->element<dictionary::ReferencedBeamSequence>()->length(),
+    dicom::DataElementHeader::UNDEFINED_LENGTH
+  );
+}


### PR DESCRIPTION
Adds ability to make lengths of `DataElement` in a data set all not be undefined.  This is done through the `UndefinedLengthRemover` class.

Additionally, a new runtime executable `vega` is defined that is installed with `make install`.  This executable has the ability to take in a DICOM file and output the same DICOM file with modifications.  Currently I have only implemented the ability to remove undefined lengths, but it can also be used as is for formatting a DICOM file in JSON or plain text formats.