### PR TITLE
Fix compiling error

### DIFF
--- a/src/vega/vr.cpp
+++ b/src/vega/vr.cpp
@@ -253,7 +253,7 @@ namespace vega {
   namespace vr {
     VR parse_vr_string(std::string s) {
       assert(s.length() == 2);
-      return VR{ {.characters = {s[0], s[1]}} };
+      return VR{ VR::Data{.characters = {s[0], s[1]}} };
     }
   }
 


### PR DESCRIPTION
This makes the VR constructor called explicit, removing a compile error
I was encountering.